### PR TITLE
Replace file watching library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var http = require("http")
     , shoe = require("shoe")
     , path = require("path")
-    , watchr = require("watchr")
+    , chokidar = require('chokidar')
     , bundle = require("browserify-server")
     , openStreams = []
 
@@ -19,12 +19,12 @@ function LiveReloadServer(options) {
             body: "require('./browser.js')(" + port + ")"
         })
 
-    watchr.watch({
-        paths: paths
-        , listener: reload
-        , ignoreHiddenFiles: true
-        , ignorePatterns: true
-    })
+    chokidar
+        .watch(paths, {
+            ignored: /[\/\\]\./,
+            ignoreInitial: true
+        })
+        .on('all', reload)
 
     sock.install(server, "/shoe")
 
@@ -52,7 +52,7 @@ function LiveReloadServer(options) {
         }
     }
 
-    function reload(fileName) {
+    function reload(changeType, fileName) {
         if (timer) {
             clearTimeout(timer)
         }

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "shoe": "0.0.5",
-    "hound": "~1.0.4",
-    "reconnect": "~0.1.3",
-    "optimist": "~0.3.4",
-    "watchr": "~2.1.5",
     "browserify-server": "~2.0.3",
-    "filed": "0.0.7"
+    "chokidar": "^1.0.5",
+    "filed": "0.0.7",
+    "hound": "~1.0.4",
+    "optimist": "~0.3.4",
+    "reconnect": "~0.1.3",
+    "shoe": "0.0.5"
   },
   "devDependencies": {},
   "licenses": [


### PR DESCRIPTION
Would you entertain swapping out watchr for chokidar for improved performance and reliability? Chokidar is very heavily used and uses fsevents for file watching on OS X. (Watchr does not support fsevents.)

See the chokidar readme for more details: https://www.npmjs.com/package/chokidar
