### PR TITLE
Bump shoe version to prevent it using unauthenticated git protocol for its dependency on sockjs-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "shoe": "0.0.5",
+    "shoe": "0.0.15",
     "hound": "~1.0.4",
     "reconnect": "~0.1.3",
     "optimist": "~0.3.4",


### PR DESCRIPTION
shoe version < 0.0.12 includes its dependency on sockjs-client as:
```
    "dependencies" : {
        "sockjs-client" : "git://github.com/substack/sockjs-client.git#browserify-npm"
    },
```

Unauthenticated git protocol usage has now been disabled in GitHub (https://github.blog/2021-09-01-improving-git-protocol-security-github/) so this dependency can't be retrieved when performing an `npm install`.

shoe version >= 0.0.12 fetches the same dependency from npm, avoiding this problem:
```
    "dependencies" : {
        "sockjs" : "0.3.7"
    },
```